### PR TITLE
Replace 200 OK with 401 Unauthorized when the user enters an incorrect username/password.

### DIFF
--- a/pages/api/v1/client/auth/login.js
+++ b/pages/api/v1/client/auth/login.js
@@ -13,10 +13,10 @@ export default async function handler(req, res) {
         email: req.body.email,
       });
       if (user_data == null)
-        return res.json({ status: "error", data: "Incorrect email/password" });
+        return res.status(401).json({ status: "error", data: "Incorrect email/password" });
       const match = await bcrypt.compare(req.body.password, user_data.password);
       if (!match)
-        return res.json({ status: "error", data: "Incorrect email/password" });
+        return res.status(401).json({ status: "error", data: "Incorrect email/password" });
       let refresh_token = jwt.sign(
         {
           type: "refresh",


### PR DESCRIPTION
This adds a little part to the login page code that'll respond with HTTP code 401 instead of HTTP code 200 when an error occurs (the user enters an incorrect username or/and password).