### PR TITLE
Fix admin creation on cockroachdb

### DIFF
--- a/configure.js
+++ b/configure.js
@@ -203,7 +203,8 @@ if (!joinNode) {
 let dbUsername = await prompts({
 type: "text",
 name: "value",
-message: "What would you like your database account's username to be?"
+message: "What would you like your database account's username to be?",
+validate: value => value != "admin"
 })
 let dbPassword = await prompts({
 type: "password",


### PR DESCRIPTION
disallow user "admin" wich errors out the script because it already exists